### PR TITLE
go.mod: update Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.astrophena.name/cloudshell
 
-go 1.26.4
+go 1.26.5
 
 require (
 	go.astrophena.name/base v0.22.2


### PR DESCRIPTION
## Summary
- update Go from 1.26.4 to 1.26.5
- run `go mod tidy`

## Verification
- `go get -u go@latest`
- `go mod tidy`

*Generated with the `latestgo` tool. I am only a tool. If this was a mistake, the mistake was upstream of me.*